### PR TITLE
feat: add direnv-run composite action for CI

### DIFF
--- a/.github/actions/direnv-run/action.yml
+++ b/.github/actions/direnv-run/action.yml
@@ -1,0 +1,36 @@
+name: Run in direnv environment
+description: Run a command inside the repo's direnv environment (.envrc) using the nix-aerie image
+
+inputs:
+  command:
+    description: Command to run inside direnv exec
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Transfer Nix store ownership to root
+      # The image's /nix store is owned by user 'dev' (uid 1000)
+      # for devcontainer compatibility. GitHub Actions container jobs run as root.
+      # Without this chown, Nix operations fail with permission errors (EPERM).
+      # Security note: no privilege escalation — the CI runner is already root.
+      run: |
+        if [ ! -d /nix ]; then
+          echo "::error::/nix directory not found — is this a nix-aerie image?"
+          exit 1
+        fi
+        chown -R root:root /nix
+      shell: bash
+
+    - name: Run command in direnv environment
+      env:
+        COMMAND_INPUT: ${{ inputs.command }}
+      run: |
+        if [ ! -f .envrc ]; then
+          echo "::error::No .envrc found in workspace root — direnv-run requires an .envrc file. Use nix-run action instead for repos without .envrc."
+          exit 1
+        fi
+        direnv allow .
+        echo "Running: direnv exec . $COMMAND_INPUT"
+        direnv exec . $COMMAND_INPUT
+      shell: bash


### PR DESCRIPTION
## Summary

New composite action at `.github/actions/direnv-run/` that brings the full local dev experience into CI — same `.envrc`, same environment, same commands.

Many projects wire everything through `.envrc`: devShell activation, dependency setup (`uv sync`, `npm install`), environment variables, path configuration. It's the single source of truth for "how to work in this repo." The existing `nix-run` action bypasses all of that by calling `nix develop` directly — useful, but it means CI and local dev can quietly diverge.

`direnv-run` closes that gap. Combined with a nix-aerie image, a CI job runs in the exact same environment a developer works in locally: `direnv allow` → `direnv exec . <command>`. No special CI setup, no drift between what runs locally and what runs in the pipeline.

**When to use which:**

| Action | Use case |
|--------|----------|
| `nix-run` | Repos without `.envrc`, or when you just need `nix develop --command` |
| `direnv-run` | Repos with `.envrc` that define the canonical environment |

## Example

```yaml
jobs:
  test:
    runs-on: ubuntu-24.04
    container:
      image: ghcr.io/eth-library/nix-aerie-python:latest
    steps:
      - uses: actions/checkout@v4
      - uses: eth-library/nix-aerie/.github/actions/direnv-run@main
        with:
          command: pytest
```

## Safety checks

- Validates `/nix` exists (catches misconfigured runners not using a nix-aerie image)
- Validates `.envrc` exists (fails with a clear message pointing to `nix-run` as the alternative)
- Uses `env:` variables instead of `${{ }}` interpolation to prevent GitHub Actions script injection