### PR TITLE
feat: multi-arch CI (amd64 + arm64)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,23 +28,34 @@ jobs:
         run: nix flake check --system x86_64-linux
 
   build-test:
-    name: Build and test (${{ matrix.variant }})
+    name: Build and test (${{ matrix.variant.name }}, ${{ matrix.arch.docker_arch }})
     needs: check
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.arch.runner }}
     strategy:
       fail-fast: false
       matrix:
+        arch:
+          - runner: ubuntu-24.04
+            nix_system: x86_64-linux
+            docker_arch: amd64
+            cst_binary: container-structure-test-linux-amd64
+            cst_sha256: "fa35e89512a8978585f76cf41397956d2e3a30c62c2ad3fb857b1597074d14ca"
+          - runner: ubuntu-24.04-arm
+            nix_system: aarch64-linux
+            docker_arch: arm64
+            cst_binary: container-structure-test-linux-arm64
+            cst_sha256: "801266c0de0b6adc0e231f0815f00f4f32eb2e0cfa1fcfc6e9c63806c09a6e26"
         # MVP variants only — go, java, k8s deferred to post-MVP
-        include:
-          - variant: base
+        variant:
+          - name: base
             image_name: nix-aerie-base:latest
             test_config: tests/variant-base.yaml
             size_max_mb: 1200
-          - variant: python
+          - name: python
             image_name: nix-aerie-python:latest
             test_config: tests/variant-python.yaml
             size_max_mb: 1800
-          - variant: default
+          - name: default
             image_name: nix-aerie:latest
             test_config: tests/structure-test.yaml
             size_max_mb: 3600
@@ -62,36 +73,35 @@ jobs:
           use-flakehub: false
 
       # Uses -tar targets for consistent :latest tags (see .reports/ci-workflow-review.md §5)
+      # Full attribute path required — shorthand only works when host == target system
       - name: Build and load image
         run: |
-          nix build .#${{ matrix.variant }}-tar --print-build-logs
+          nix build .#packages.${{ matrix.arch.nix_system }}.${{ matrix.variant.name }}-tar --print-build-logs
           docker load < result
 
       # Install container-structure-test (v1.22.1, SHA256 verified)
       - name: Install container-structure-test
         run: |
           CST_VERSION="1.22.1"
-          # SHA256 from dev/flake.nix SRI hash, converted to hex
-          CST_SHA256="fa35e89512a8978585f76cf41397956d2e3a30c62c2ad3fb857b1597074d14ca"
           curl -fsSL \
-            "https://github.com/GoogleContainerTools/container-structure-test/releases/download/v${CST_VERSION}/container-structure-test-linux-amd64" \
+            "https://github.com/GoogleContainerTools/container-structure-test/releases/download/v${CST_VERSION}/${{ matrix.arch.cst_binary }}" \
             -o /usr/local/bin/container-structure-test
-          echo "${CST_SHA256}  /usr/local/bin/container-structure-test" | sha256sum -c
+          echo "${{ matrix.arch.cst_sha256 }}  /usr/local/bin/container-structure-test" | sha256sum -c
           chmod +x /usr/local/bin/container-structure-test
 
       # Each variant runs its own structure test file
       - name: Run structure tests
         run: |
           container-structure-test test \
-            --image ${{ matrix.image_name }} \
-            --config ${{ matrix.test_config }}
+            --image ${{ matrix.variant.image_name }} \
+            --config ${{ matrix.variant.test_config }}
 
       # Image size guardrail — catch unexpected bloat
       - name: Check image size
         env:
-          IMAGE_NAME: ${{ matrix.image_name }}
-          MAX_MB: ${{ matrix.size_max_mb }}
-          VARIANT: ${{ matrix.variant }}
+          IMAGE_NAME: ${{ matrix.variant.image_name }}
+          MAX_MB: ${{ matrix.variant.size_max_mb }}
+          VARIANT: ${{ matrix.variant.name }}
         run: |
           MAX_BYTES=$(( MAX_MB * 1024 * 1024 ))
           ACTUAL=$(docker inspect --format='{{.Size}}' "$IMAGE_NAME")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
             nix_system: aarch64-linux
             docker_arch: arm64
             cst_binary: container-structure-test-linux-arm64
-            cst_sha256: "801266c0de0b6adc0e231f0815f00f4f32eb2e0cfa1fcfc6e9c63806c09a6e26"
+            cst_sha256: "801826ed107222120eb6df8c143b7de752cfebbe3aebfeea576e7098486917c2"
         # MVP variants only — go, java, k8s deferred to post-MVP
         variant:
           - name: base

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
   push:
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
     name: Build and test (${{ matrix.variant.name }}, ${{ matrix.arch.docker_arch }})
     needs: check
     runs-on: ${{ matrix.arch.runner }}
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -49,14 +52,17 @@ jobs:
         variant:
           - name: base
             image_name: nix-aerie-base:latest
+            registry_image: ghcr.io/eth-library/nix-aerie-base
             test_config: tests/variant-base.yaml
             size_max_mb: 1200
           - name: python
             image_name: nix-aerie-python:latest
+            registry_image: ghcr.io/eth-library/nix-aerie-python
             test_config: tests/variant-python.yaml
             size_max_mb: 1800
           - name: default
             image_name: nix-aerie:latest
+            registry_image: ghcr.io/eth-library/nix-aerie
             test_config: tests/structure-test.yaml
             size_max_mb: 3600
 
@@ -110,6 +116,21 @@ jobs:
             exit 1
           fi
           echo "OK: :${VARIANT} is $(numfmt --to=iec "$ACTUAL") (max $(numfmt --to=iec "$MAX_BYTES"))"
+
+      - name: Log in to GHCR
+        if: github.ref == 'refs/heads/main'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push arch-specific tag
+        if: github.ref == 'refs/heads/main'
+        run: |
+          docker tag "${{ matrix.variant.image_name }}" \
+            "${{ matrix.variant.registry_image }}:latest-${{ matrix.arch.docker_arch }}"
+          docker push "${{ matrix.variant.registry_image }}:latest-${{ matrix.arch.docker_arch }}"
 
   publish:
     name: Publish (${{ matrix.variant }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,8 +133,9 @@ jobs:
           docker push "${{ matrix.variant.registry_image }}:latest-${{ matrix.arch.docker_arch }}"
 
   publish:
-    name: Publish (${{ matrix.variant }})
+    name: Publish manifest (${{ matrix.variant.name }})
     needs: build-test
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -142,29 +143,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - variant: base
-            image_name: nix-aerie-base:latest
+        variant:
+          - name: base
             registry_image: ghcr.io/eth-library/nix-aerie-base
-          - variant: python
-            image_name: nix-aerie-python:latest
+          - name: python
             registry_image: ghcr.io/eth-library/nix-aerie-python
-          - variant: default
-            image_name: nix-aerie:latest
+          - name: default
             registry_image: ghcr.io/eth-library/nix-aerie
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
-
-      - name: Enable Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
-        with:
-          use-flakehub: false
-
       - name: Log in to GHCR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
@@ -172,16 +159,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Rebuild uses Nix cache — only docker load + push cost time
-      - name: Build and load image
+      - name: Create and push multi-arch manifest
         run: |
-          nix build .#${{ matrix.variant }}-tar --print-build-logs
-          docker load < result
-
-      - name: Tag and push
-        env:
-          LOCAL: ${{ matrix.image_name }}
-          REMOTE: ${{ matrix.registry_image }}
-        run: |
-          docker tag "${LOCAL}" "${REMOTE}:latest"
-          docker push "${REMOTE}:latest"
+          docker manifest create ${{ matrix.variant.registry_image }}:latest \
+            --amend ${{ matrix.variant.registry_image }}:latest-amd64 \
+            --amend ${{ matrix.variant.registry_image }}:latest-arm64
+          docker manifest push ${{ matrix.variant.registry_image }}:latest

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The nixpkgs source tree (~32 MB compressed) is also included in the Nix store, s
 - **Single-user Nix**, the container standard; no daemon or systemd required.
 - **`USER=dev`** in the image, ready for devcontainers and `docker run` out of the box.
 - **One `flake.lock`** pins all shells to the same nixpkgs revision, guaranteeing store-path deduplication across variants.
-- **Architecture**: `linux/amd64` for Codespaces; `linux/arm64` available in `flake.nix` for local testing on Apple Silicon.
+- **Architecture**: Multi-arch (`linux/amd64` + `linux/arm64`) published as OCI manifests — `docker pull` selects the native image automatically, including on Apple Silicon.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Add architecture matrix (amd64 + arm64) to `build-test` job — 6 parallel jobs (3 variants × 2 archs) on native runners
- Push arch-specific tags (`:latest-amd64`, `:latest-arm64`) from `build-test` on main
- Replace `publish` job with lightweight manifest-only creation (`docker manifest create/push`)
- Update README architecture line

Closes #10 — Publish multi-arch images (amd64 + arm64) for native Apple Silicon support

## Test plan

- [x] All 6 build-test jobs pass (base/python/default × amd64/arm64)
- [x] Publish jobs skipped on PR branch (expected)
- [x] After merge: publish creates multi-arch manifests
- [x] `docker manifest inspect` shows both amd64 and arm64 entries
- [x] `docker pull` on Apple Silicon gets native arm64 image